### PR TITLE
Change the order of library compilations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ THREADS = -j8
 CLANG = ${DEST}/bin/clang
 
 all: check-source cmake install libraries
-libraries: compiler-rt libunwind libcxxabi libcxx openmp
+libraries: compiler-rt libunwind libcxx-headers libcxxabi libcxx openmp
 
 musl:
 	make TARGET=ve-linux-musl all
@@ -66,7 +66,7 @@ build:
 install: build
 	cd ${LLVM_BUILDDIR} && ${NINJA} ${THREADS} install
 
-installall: install compiler-rt libunwind libcxxabi libcxx openmp
+installall: install compiler-rt libunwind libcxx-headers libcxxabi libcxx openmp
 
 build-debug:
 	make LLVM_BUILDDIR=${LLVMDBG_BUILDDIR} DEST=${DBG_DEST} \
@@ -123,6 +123,15 @@ libcxxabi:
 
 check-libcxxabi: libcxxabi
 	cd libcxxabi && ${NINJA} ${THREADS} check-cxxabi
+
+libcxx-headers:
+	mkdir -p ${CXX_BUILDDIR}
+	cd ${CXX_BUILDDIR} && CMAKE=${CMAKE} DEST=${DEST} TARGET=${TARGET} \
+	    BUILD_TYPE=${BUILD_TYPE} OPTFLAGS="${OPTFLAGS}" \
+	    RESDIR=${RESDIR} LIBSUFFIX=${LIBSUFFIX} \
+	    SRCDIR=${SRCDIR} TOOLDIR=${TOOLDIR} \
+	    ${LLVM_DEV_DIR}/scripts/cmake-libcxx.sh
+	cd ${CXX_BUILDDIR} && ${NINJA} ${THREADS} install-cxx-headers
 
 libcxx:
 	mkdir -p ${CXX_BUILDDIR}

--- a/scripts/cmake-libcxxabi.sh
+++ b/scripts/cmake-libcxxabi.sh
@@ -19,6 +19,7 @@ $CMAKE -G Ninja \
   -DLLVM_MAIN_SRC_DIR=$SRCDIR/llvm \
   -DLIBCXXABI_USE_COMPILER_RT=True \
   -DLIBCXXABI_HAS_NOSTDINCXX_FLAG=True \
+  -DLIBCXXABI_LIBCXX_INCLUDES="$RESDIR/include/c++/v1/" \
   $SRCDIR/libcxxabi
 
 # Modify lit.site.cfg to pass installed libraries' path


### PR DESCRIPTION
Change to isntall libcxx header files before libcxxabi complation
in order to follow 1687f2b, "[libcxxabi] Use cxx-headers target to
consume libcxx headers."

This modification is required to compile the develop branch of
llvm-ve after [#45](https://github.com/sx-aurora-dev/llvm-project/pull/45).