### PR TITLE
Change to fix problems caused by f2f88f3.

### DIFF
--- a/scripts/cmake-openmp.sh
+++ b/scripts/cmake-openmp.sh
@@ -16,6 +16,9 @@ $CMAKE -G Ninja \
   -DCMAKE_C_FLAGS_RELEASE="$OPTFLAGS" \
   -DLIBOMP_ARCH="$OMPARCH" \
   -DOPENMP_LLVM_TOOLS_DIR=$TOOLDIR \
+  -DLLVM_DIR="$DEST/lib/cmake/llvm" \
+  -DZLIB_LIBRARY="/lib/x86_64-linux-gnu/" \
+  -DCMAKE_SKIP_RPATH=true \
   $SRCDIR/openmp
 
 # Modify lit.site.cfg to test on VE
@@ -24,4 +27,19 @@ sed -e 's:test_openmp_flags = ":test_openmp_flags = "-target ve-linux -frtlib-ad
 
 # Add -j1 to llvm-lit
 sed -e 's:llvm-lit:llvm-lit -j1:' \
+    -i build.ninja
+
+# Fix include problem caused by f2f88f3
+# It tries to read header files for host.
+sed -e 's:-isystem /usr/include::' \
+    -i build.ninja
+
+# Fix library target problem caused by f2f88f3
+# It tries to link library files for host.
+sed -e 's:\(build libomptarget/libomptarget.so.*\) |.*$:\1:' \
+    -i build.ninja
+
+# Fix link library problem caused by f2f88f3
+# It tries to link library files for host.
+sed -e 's:LINK_LIBRARIES = .*/libLLVMSupport.a.*\(-ldl *-Wl,--version-script=.*/exports\).*:LINK_LIBRARIES = \1:' \
     -i build.ninja


### PR DESCRIPTION
In the llvm-ve develop branch, f2f88f3 merged in upstream introduces compile problem.
After that, cmake generates scripts to link libomptarger.so for VE with libLLVMSupport.a for VH.

This modificationodification hacks cmake generated scripts to comile omptarget for VE in previous manner.
We still need to follow upstream thought and moves, though.