### PR TITLE
[VE] Change to link with `-lrt` for openmp

### DIFF
--- a/scripts/cmake-openmp.sh
+++ b/scripts/cmake-openmp.sh
@@ -22,7 +22,7 @@ $CMAKE -G Ninja \
   $SRCDIR/openmp
 
 # Modify lit.site.cfg to test on VE
-sed -e 's:test_openmp_flags = ":test_openmp_flags = "-target ve-linux -frtlib-add-rpath -ldl :' \
+sed -e 's:test_openmp_flags = ":test_openmp_flags = "-target ve-linux -frtlib-add-rpath -ldl -lrt :' \
     -i runtime/test/lit.site.cfg
 
 # Add -j1 to llvm-lit


### PR DESCRIPTION
Recently ncc changed library placements.  Now, it is required to link
runtime library in order to use shm_* related functions.