### PR TITLE
Change clean target to remove install directory also

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,11 +164,10 @@ deep-update:
 
 clean:
 	${RM} -rf ${LLVM_BUILDDIR} ${CMPRT_BUILDDIR} ${RUNTIMES_BUILDDIR} \
-            ${OPENMP_BUILDDIR} ${LLVMDBG_BUILDDIR}
+            ${OPENMP_BUILDDIR} ${LLVMDBG_BUILDDIR} ${DEST}
 	-${RMDIR} ${BUILDDIR}
 
 distclean: clean
-	${RM} -rf ${DEST}
 #	${RM} -rf ${SRCDIR}
 
 FORCE:


### PR DESCRIPTION
Sometime, compiling without removing isntall directory causes compile error in a regression test script.  It is up to the upstream modification, so it is not possible to control this by us.  Therefore, I change a clean target in Makefile to remove not only build directory but also install directory.