### PR TITLE
[VE] Change to not compile libomptarget for VE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ LLVMDBG_BUILDDIR = ${BUILDDIR}/build-debug
 CMPRT_BUILDDIR = ${BUILDDIR}/compiler-rt
 RUNTIMES_BUILDDIR = ${BUILDDIR}/runtimes
 OPENMP_BUILDDIR = ${BUILDDIR}/openmp
+LIBOMPTARGET_BUILDDIR = ${BUILDDIR}/libomptarget
 # RESDIR requires trailing '/'.
 LLVM_VERSION_MAJOR = $(shell grep 'set.*LLVM_VERSION_MAJOR  *' ${SRCDIR}/llvm/CMakeLists.txt | sed -e 's/.*LLVM_VERSION_MAJOR //' -e 's/[^0-9][^0-9]*//')
 LLVM_VERSION_MINOR = $(shell grep 'set.*LLVM_VERSION_MINOR  *' ${SRCDIR}/llvm/CMakeLists.txt | sed -e 's/.*LLVM_VERSION_MINOR //' -e 's/[^0-9][^0-9]*//')
@@ -145,6 +146,14 @@ openmp:
 
 check-openmp: openmp
 	cd openmp && ${NINJA} -j${COMPILE_THREADS} check-openmp
+
+libomptarget:
+	mkdir -p ${LIBOMPTARGET_BUILDDIR}
+	cd ${LIBOMPTARGET_BUILDDIR} && CMAKE=${CMAKE} DEST=${DEST} \
+	    RESDIR=${RESDIR} BUILD_TYPE=${BUILD_TYPE} OPTFLAGS="${OPTFLAGS}" \
+	    TARGET=${VE_TRIPLE} SRCDIR=${SRCDIR} TOOLDIR=${TOOLDIR} \
+	    ${LLVM_DEV_DIR}/scripts/cmake-libomptarget.sh
+	cd ${LIBOMPTARGET_BUILDDIR} && ${NINJA} -j${COMPILE_THREADS} install
 
 shallow:
 	REPO=${REPO} BRANCH=${BRANCH} SRCDIR=${SRCDIR} \

--- a/scripts/cmake-libomptarget.sh
+++ b/scripts/cmake-libomptarget.sh
@@ -14,10 +14,13 @@ $CMAKE -G Ninja \
   -DLLVM_DIR="$DEST/lib/cmake/llvm" \
   -DOPENMP_LIBDIR_SUFFIX="/$TARGET" \
   -DOPENMP_LLVM_TOOLS_DIR=$TOOLDIR \
-  -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
   -DOPENMP_ENABLE_LIBOMPTARGET_PROFILING=OFF \
   -DLIBOMP_HAVE_SHM_OPEN_WITH_LRT=ON \
   $SRCDIR/openmp
+
+# Disable TERMINFO and ZLIB since those are enabled by default and cause
+# compile error in libomptarget.  I believe the source of problem is
+# libomptarget since accelarator never requires terminfo.
 
 # Modify lit.site.cfg to test on VE
 #sed -e 's:test_openmp_flags = ":test_openmp_flags = "-target ve-linux -frtlib-add-rpath -ldl -lrt :' \


### PR DESCRIPTION
Change to not compile libomptarget for VE at the moment since it is
not compilable after https://reviews.llvm.org/D129875.

If you want to try to compile it to fix problems, please try `make libomptarget`
instead of `make openmp`.